### PR TITLE
Remove VSCode from list of MCP install providers

### DIFF
--- a/cli/GK-CLI-mcp.md
+++ b/cli/GK-CLI-mcp.md
@@ -38,7 +38,6 @@ Supported LLM applications:
 - Claude
 - Windsurf
 - Cursor
-- VSCode
 - Zed
 
 ### Self Installation 


### PR DESCRIPTION
Removed VSCode from mcp install <platform> providers while we get a hotfix out 